### PR TITLE
Add site name to title.

### DIFF
--- a/views/layouts/master.blade.php
+++ b/views/layouts/master.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>
         @section('title')
-        Admin
+        {{ Setting::get('core::site-name') }} | Admin
         @show
     </title>
     <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'>


### PR DESCRIPTION
When managing multiple CMSes, it can get slightly confusing when all you see in the tab's title is "Admin". Ok...Admin of which site again exactly?

(This is a silly thing to change, in reality...but maybe someone else has the same problem too.)
