### PR TITLE
Add slugify to main.js from app.js (which is not loaded/used)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $("form").sisyphus({locationBased: true});
+    $("form").sisyphus({locationBased: true, excludeFields: $('input[name="_token"]')});
     if ($('.slugify').length) {
         $('.slugify').slug({
             slug: 'slug',       // class of input / span that contains the generated slug

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,9 @@
 $(document).ready(function () {
     $("form").sisyphus({locationBased: true});
+    if ($('.slugify').length) {
+        $('.slugify').slug({
+            slug: 'slug',       // class of input / span that contains the generated slug
+            hide: false        // hide the text input, true by default
+        });
+    }
 });


### PR DESCRIPTION
The file {resources,assets}/js/app.js does not appear to be loaded
by the Asset Manager. I tried to compare that file to the vendor-
supplied copy from AdminLTE:

public/themes/adminlte/vendor/admin-lte/dist/js/app.js

but the files are way to different to really tell what else might
be missing.

If I have time later on, I'll go through all the assets (loaded via core.core.admin-assets config value) and sync things up.
